### PR TITLE
Add search form to default landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,14 @@
         <h1>Und*ck</h1>
         <p>DuckDuckGo's bang redirects are too slow. Add the following URL as a custom search engine to your browser.
           Enables <a href="https://duckduckgo.com/bang.html" target="_blank">all of DuckDuckGo's bangs.</a></p>
+        <div class="search-container">
+          <form class="search-form" autocomplete="off">
+            <label class="sr-only" for="search-input">Search query</label>
+            <input id="search-input" class="search-input" type="search" name="q"
+              placeholder="Try typing !g unduck" />
+            <button class="search-button" type="submit">Search</button>
+          </form>
+        </div>
         <div class="url-container">
           <input type="url" class="url-input" value="" readonly />
           <button class="copy-button">

--- a/src/global.css
+++ b/src/global.css
@@ -93,6 +93,54 @@ textarea {
   padding: 0 8px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.search-container {
+  margin-top: 24px;
+}
+
+.search-form {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.search-input {
+  padding: 10px 14px;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+  min-width: min(100%, 320px);
+  background-color: #fff;
+}
+
+.search-button {
+  padding: 10px 20px;
+  background-color: #1a1a1a;
+  color: #fff;
+  border-radius: 999px;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+}
+
+.search-button:hover {
+  background-color: #333;
+}
+
+.search-button:active {
+  background-color: #000;
+}
+
 /* Update url-input width to be 100% since container will control max width */
 .url-input {
   padding: 8px 12px;
@@ -174,6 +222,25 @@ textarea {
 
   .footer a:hover {
     color: #ccc;
+  }
+
+  .search-input {
+    border-color: #3d3d3d;
+    background-color: #191919;
+    color: #fff;
+  }
+
+  .search-button {
+    background-color: #f5f5f5;
+    color: #000;
+  }
+
+  .search-button:hover {
+    background-color: #e5e5e5;
+  }
+
+  .search-button:active {
+    background-color: #d9d9d9;
   }
 
   .url-input {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,25 @@ function noSearchDefaultPageRender() {
       copyIcon.src = "/clipboard.svg";
     }, 2000);
   });
+
+  const searchForm = app.querySelector<HTMLFormElement>(".search-form");
+  const searchInput = app.querySelector<HTMLInputElement>(".search-input");
+
+  if (searchForm && searchInput) {
+    searchForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const query = searchInput.value.trim();
+
+      if (!query) {
+        searchInput.focus();
+        return;
+      }
+
+      const nextUrl = new URL(window.location.href);
+      nextUrl.searchParams.set("q", query);
+      window.location.href = nextUrl.toString();
+    });
+  }
 }
 
 const LS_DEFAULT_BANG = localStorage.getItem("default-bang") ?? "g";


### PR DESCRIPTION
## Summary
- add a search form to the default landing page so users can try queries without editing the URL
- wire the search form to reuse the existing redirect flow when a query is submitted
- style the search controls, including an accessible label and dark-mode adjustments

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68f94711cc44832fb2665b1a24f1239b