### PR TITLE
Adjust input padding to prevent text clipping

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -114,12 +114,13 @@ textarea {
 .search-input {
   flex: 1;
   min-width: 0;
-  padding: 8px 10px;
+  padding: 12px 10px;
   border: none;
   border-radius: 8px;
   background: transparent;
   color: inherit;
   appearance: none;
+  line-height: 1.4;
 }
 
 .search-input:focus {
@@ -176,13 +177,14 @@ textarea {
 
 /* Update url-input width to be 100% since container will control max width */
 .url-input {
-  padding: 8px 12px;
+  padding: 12px 14px;
   border: 1px solid var(--surface-border);
   border-radius: 12px;
   width: 100%;
   background: var(--surface-color);
   color: inherit;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  line-height: 1.4;
 }
 
 

--- a/src/global.css
+++ b/src/global.css
@@ -171,7 +171,7 @@ textarea {
   display: grid;
   gap: 24px;
   justify-items: center;
-  max-width: 36rem;
+  max-width: 44rem;
   text-align: center;
   padding: 0 12px;
 }

--- a/src/global.css
+++ b/src/global.css
@@ -114,13 +114,14 @@ textarea {
 .search-input {
   flex: 1;
   min-width: 0;
-  padding: 12px 10px;
+  padding: 14px 12px;
   border: none;
   border-radius: 8px;
   background: transparent;
   color: inherit;
   appearance: none;
-  line-height: 1.4;
+  line-height: 1.5;
+  min-height: 52px;
 }
 
 .search-input:focus {
@@ -177,14 +178,15 @@ textarea {
 
 /* Update url-input width to be 100% since container will control max width */
 .url-input {
-  padding: 12px 14px;
+  padding: 14px 16px;
   border: 1px solid var(--surface-border);
   border-radius: 12px;
   width: 100%;
   background: var(--surface-color);
   color: inherit;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-  line-height: 1.4;
+  line-height: 1.5;
+  min-height: 52px;
 }
 
 

--- a/src/global.css
+++ b/src/global.css
@@ -159,21 +159,30 @@ textarea {
 }
 
 
+.content-container {
+  display: grid;
+  gap: 28px;
+  width: min(72rem, calc(100vw - clamp(48px, 10vw, 128px)));
+  margin: 0 auto;
+  text-align: center;
+  padding: 0 16px;
+}
+
+.content-container > * {
+  width: 100%;
+}
+
+.search-container,
+.search-form {
+  width: 100%;
+}
+
 .url-container {
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
   gap: 12px;
   width: 100%;
-}
-
-.content-container {
-  display: grid;
-  gap: 24px;
-  justify-items: center;
-  max-width: 44rem;
-  text-align: center;
-  padding: 0 12px;
 }
 
 /* Update url-input width to be 100% since container will control max width */


### PR DESCRIPTION
## Summary
- increase vertical padding and line-height for the search and URL inputs so text renders fully

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_6905147a9970832f911e98f6df3e7992